### PR TITLE
feat: Add an external_only setting to image/link plugins 

### DIFF
--- a/src/plugins/image/src/main/js/api/Settings.js
+++ b/src/plugins/image/src/main/js/api/Settings.js
@@ -45,6 +45,10 @@ define(
       return editor.getParam('image_list', false);
     };
 
+    var isExternalOnly = function (editor) {
+      return editor.getParam('image_external_only', false);
+    };
+
     return {
       hasDimensions: hasDimensions,
       hasAdvTab: hasAdvTab,
@@ -53,7 +57,8 @@ define(
       hasDescription: hasDescription,
       hasImageTitle: hasImageTitle,
       hasImageCaption: hasImageCaption,
-      getImageList: getImageList
+      getImageList: getImageList,
+      isExternalOnly: isExternalOnly
     };
   }
 );

--- a/src/plugins/image/src/main/js/core/Utils.js
+++ b/src/plugins/image/src/main/js/core/Utils.js
@@ -15,11 +15,12 @@
 define(
   'tinymce.plugins.image.core.Utils',
   [
+    'tinymce.plugins.image.api.Settings',
     'tinymce.core.util.Tools',
     'global!Math',
     'global!document'
   ],
-  function (Tools, Math, document) {
+  function (Settings, Tools, Math, document) {
 
     var getImageSize = function (url, callback) {
       var img = document.createElement('img');
@@ -266,6 +267,28 @@ define(
       return enabledIntegrationLabels.join(' or ');
     };
 
+   /**
+    * Helper method that returns a string containing the source type (internal or external) of the image
+    * based on the image source or given editor's settings.
+    *
+    * @param {object} imageElement
+    * @param {string} imageSource
+    * @param {tinymce.Editor} editor
+    * @return {string}
+    */
+    var getSourceType = function (imageElement, imageSource, editor) {
+      if (Settings.isExternalOnly(editor)) {
+        return 'external';
+      }
+
+      //default to internal images
+      if (imageElement === null || isInternalUrl(imageSource)) {
+        return 'internal';
+      } else {
+        return 'external';
+      }
+    };
+
     return {
       getImageSize: getImageSize,
       buildListItems: buildListItems,
@@ -281,7 +304,8 @@ define(
       internalPathToRenderFileURL: internalPathToRenderFileURL,
       isInternalUrl: isInternalUrl,
       convertTinyMCEFieldToJqueryObject: convertTinyMCEFieldToJqueryObject,
-      generateEnabledDAMIntegrationsLabelFromEditorSettings: generateEnabledDAMIntegrationsLabelFromEditorSettings
+      generateEnabledDAMIntegrationsLabelFromEditorSettings: generateEnabledDAMIntegrationsLabelFromEditorSettings,
+      getSourceType: getSourceType
     };
   }
 );

--- a/src/plugins/image/src/main/js/ui/Dialog.js
+++ b/src/plugins/image/src/main/js/ui/Dialog.js
@@ -525,7 +525,7 @@ define(
           };
         }
 
-        data.source_type = (imgElm === null || Utils.isInternalUrl(data.src)) && !Settings.isExternalOnly(editor) ? 'internal' : 'external';
+        data.source_type = Utils.getSourceType(imgElm, data.src, editor);
 
         // General settings shared between simple and advanced dialogs
         var generalFormItems = [];

--- a/src/plugins/image/src/main/js/ui/Dialog.js
+++ b/src/plugins/image/src/main/js/ui/Dialog.js
@@ -536,7 +536,7 @@ define(
           type: 'textbox',
           size: 40,
           label: 'Image Source',
-          value: data.source_type === 'external' ? data.src : 'https://',
+          value: data.source_type === 'external' && data.src ? data.src : 'https://',
           onchange: onSrcChange
         };
 

--- a/src/plugins/image/src/main/js/ui/Dialog.js
+++ b/src/plugins/image/src/main/js/ui/Dialog.js
@@ -590,26 +590,26 @@ define(
             };
           }
 
-            var damIntegrationBrowseLabel = Utils.generateEnabledDAMIntegrationsLabelFromEditorSettings(editor);
-            if (damIntegrationBrowseLabel.length) {
-              srcCtrl.items.push({
-                type: 'container',
-                name: 'damassetChooserLink',
-                label: '',
-                layout: 'flex',
-                direction: 'column',
-                align: 'center',
-                spacing: 5,
-                hidden: true,
-                items: [
-                  {
-                    name: 'damassetChooserLinkHtml',
-                    type: 'container',
-                    html: '<a href="javascript:void(0);" class="damasset-chooser">Browse ' + damIntegrationBrowseLabel + ' for external images</a>'
-                  }
-                ]
-              });
-            }
+          var damIntegrationBrowseLabel = Utils.generateEnabledDAMIntegrationsLabelFromEditorSettings(editor);
+          if (damIntegrationBrowseLabel.length) {
+            srcCtrl.items.push({
+              type: 'container',
+              name: 'damassetChooserLink',
+              label: '',
+              layout: 'flex',
+              direction: 'column',
+              align: 'center',
+              spacing: 5,
+              hidden: true,
+              items: [
+                {
+                  name: 'damassetChooserLinkHtml',
+                  type: 'container',
+                  html: '<a href="javascript:void(0);" class="damasset-chooser">Browse ' + damIntegrationBrowseLabel + ' for external images</a>'
+                }
+              ]
+            });
+          }
         }
 
         generalFormItems.push(srcCtrl);

--- a/src/plugins/image/src/main/js/ui/Dialog.js
+++ b/src/plugins/image/src/main/js/ui/Dialog.js
@@ -525,7 +525,7 @@ define(
           };
         }
 
-        data.source_type = imgElm === null || Utils.isInternalUrl(data.src) ? 'internal' : 'external';
+        data.source_type = (imgElm === null || Utils.isInternalUrl(data.src)) && !Settings.isExternalOnly(editor) ? 'internal' : 'external';
 
         // General settings shared between simple and advanced dialogs
         var generalFormItems = [];
@@ -540,73 +540,76 @@ define(
           onchange: onSrcChange
         };
 
-        // If the type-ahead HTML generation didn't fail, create the internal/external toggler and separate source controls.
-        if (typeAheadFieldHtml.length) {
-          generalFormItems.push({
-            type: 'container',
-            label: 'Image Type',
-            layout: 'flex',
-            direction: 'row',
-            align: 'center',
-            spacing: 5,
-            items: [
-              {
-                name: 'source_type_internal',
-                type: 'checkbox',
-                checked: data.source_type === 'internal',
-                onclick: toggleLinkFields,
-                text: 'Internal'
-              },
-              {
-                name: 'source_type_external',
-                type: 'checkbox',
-                checked: data.source_type === 'external',
-                onclick: toggleLinkFields,
-                text: 'External'
-              }
-            ]
-          });
-
-          // Set the default visibility of the external source control.
-          srcCtrl.hidden = data.source_type !== 'external';
-
-          // Turn the control into a container, with the original added as one of the items.
-          srcCtrl = {
-            type: 'container',
-            name: 'sourceContainer',
-            label: 'Image Source',
-            minHeight: 60,
-            items: [
-              srcCtrl,
-              {
-                name: 'internalSrc',
-                type: 'container',
-                hidden: data.source_type !== 'internal',
-                html: typeAheadFieldHtml
-              }
-            ]
-          };
-
-          var damIntegrationBrowseLabel = Utils.generateEnabledDAMIntegrationsLabelFromEditorSettings(editor);
-          if (damIntegrationBrowseLabel.length) {
-            srcCtrl.items.push({
+        //Don't show source type options when the use external only option is specified
+        if (!Settings.isExternalOnly(editor)) {
+          // If the type-ahead HTML generation didn't fail, create the internal/external toggler and separate source controls.
+          if (typeAheadFieldHtml.length) {
+            generalFormItems.push({
               type: 'container',
-              name: 'damassetChooserLink',
-              label: '',
+              label: 'Image Type',
               layout: 'flex',
-              direction: 'column',
+              direction: 'row',
               align: 'center',
               spacing: 5,
-              hidden: true,
               items: [
                 {
-                  name: 'damassetChooserLinkHtml',
-                  type: 'container',
-                  html: '<a href="javascript:void(0);" class="damasset-chooser">Browse ' + damIntegrationBrowseLabel + ' for external images</a>'
+                  name: 'source_type_internal',
+                  type: 'checkbox',
+                  checked: data.source_type === 'internal',
+                  onclick: toggleLinkFields,
+                  text: 'Internal'
+                },
+                {
+                  name: 'source_type_external',
+                  type: 'checkbox',
+                  checked: data.source_type === 'external',
+                  onclick: toggleLinkFields,
+                  text: 'External'
                 }
               ]
             });
+
+            // Set the default visibility of the external source control.
+            srcCtrl.hidden = data.source_type !== 'external';
+
+            // Turn the control into a container, with the original added as one of the items.
+            srcCtrl = {
+              type: 'container',
+              name: 'sourceContainer',
+              label: 'Image Source',
+              minHeight: 60,
+              items: [
+                srcCtrl,
+                {
+                  name: 'internalSrc',
+                  type: 'container',
+                  hidden: data.source_type !== 'internal',
+                  html: typeAheadFieldHtml
+                }
+              ]
+            };
           }
+
+            var damIntegrationBrowseLabel = Utils.generateEnabledDAMIntegrationsLabelFromEditorSettings(editor);
+            if (damIntegrationBrowseLabel.length) {
+              srcCtrl.items.push({
+                type: 'container',
+                name: 'damassetChooserLink',
+                label: '',
+                layout: 'flex',
+                direction: 'column',
+                align: 'center',
+                spacing: 5,
+                hidden: true,
+                items: [
+                  {
+                    name: 'damassetChooserLinkHtml',
+                    type: 'container',
+                    html: '<a href="javascript:void(0);" class="damasset-chooser">Browse ' + damIntegrationBrowseLabel + ' for external images</a>'
+                  }
+                ]
+              });
+            }
         }
 
         generalFormItems.push(srcCtrl);

--- a/src/plugins/link/src/main/js/api/Settings.js
+++ b/src/plugins/link/src/main/js/api/Settings.js
@@ -82,6 +82,10 @@ define(
       return editorSettings.link_anchor !== false;
     };
 
+    var isExternalOnly = function (editor) {
+      return editor.getParam('link_external_only', false);
+    };
+
     return {
       assumeExternalTargets: assumeExternalTargets,
       hasContextToolbar: hasContextToolbar,
@@ -97,7 +101,8 @@ define(
       hasLinkClassList: hasLinkClassList,
       shouldShowLinkTitle: shouldShowLinkTitle,
       allowUnsafeLinkTarget: allowUnsafeLinkTarget,
-      shouldShowLinkAnchor: shouldShowLinkAnchor
+      shouldShowLinkAnchor: shouldShowLinkAnchor,
+      isExternalOnly: isExternalOnly
     };
   }
 );

--- a/src/plugins/link/src/main/js/core/Utils.js
+++ b/src/plugins/link/src/main/js/core/Utils.js
@@ -312,6 +312,27 @@ define(
       return enabledIntegrationLabels.join(' or ');
     };
 
+   /**
+    * Helper method that returns a string containing the source type (internal or external) of the link
+    * based on the href or given editor's settings.
+    *
+    * @param {string}
+    * @param {tinymce.Editor} editor
+    * @return {string}
+    */
+    var getSourceType = function (href, editor) {
+      if (Settings.isExternalOnly(editor)) {
+        return 'external';
+      }
+
+      //Has an internal Url or none at all, default to internal
+      if (isInternalUrl(href) || href === '') {
+        return 'internal';
+      } else {
+        return 'external';
+      }
+    };
+
     return {
       link: link,
       unlink: unlink,
@@ -331,7 +352,8 @@ define(
       isInternalUrl: isInternalUrl,
       splitUrlByHash: splitUrlByHash,
       convertTinyMCEFieldToJqueryObject: convertTinyMCEFieldToJqueryObject,
-      generateEnabledDAMIntegrationsLabelFromEditorSettings: generateEnabledDAMIntegrationsLabelFromEditorSettings
+      generateEnabledDAMIntegrationsLabelFromEditorSettings: generateEnabledDAMIntegrationsLabelFromEditorSettings,
+      getSourceType: getSourceType
     };
   }
 );

--- a/src/plugins/link/src/main/js/ui/Dialog.js
+++ b/src/plugins/link/src/main/js/ui/Dialog.js
@@ -222,8 +222,7 @@ define(
       }
 
       // Determine the source type based on the link's href value, or default to internal if empty.
-      data.source_type = (Utils.isInternalUrl(data.href) || data.href === '') && !Settings.isExternalOnly(editor) ? 'internal' : 'external';
-
+      data.source_type = Utils.getSourceType (data.href, editor);
       if (anchorElm) {
         data.target = dom.getAttrib(anchorElm, 'target');
       } else if (Settings.hasDefaultLinkTarget(editor.settings)) {

--- a/src/plugins/link/src/main/js/ui/Dialog.js
+++ b/src/plugins/link/src/main/js/ui/Dialog.js
@@ -255,7 +255,7 @@ define(
 
       //Don't show source type options when the use external only option is specified
       if (!Settings.isExternalOnly(editor)) {
-      // If the type-ahead HTML generation didn't fail, create the internal/external toggler and separate URL controls.
+        // If the type-ahead HTML generation didn't fail, create the internal/external toggler and separate URL controls.
         if (typeAheadFieldHtml) {
           sourceTypeCtrl = {
             type: 'container',
@@ -322,7 +322,7 @@ define(
             });
           }
         }
-    }
+      }
 
       if (Settings.shouldShowLinkAnchor(editor.settings)) {
         anchorCtrl = {

--- a/src/plugins/link/src/main/js/ui/Dialog.js
+++ b/src/plugins/link/src/main/js/ui/Dialog.js
@@ -248,7 +248,7 @@ define(
         type: 'textbox',
         size: 40,
         label: 'Link Source',
-        value: data.source_type === 'external' ? data.href : 'https://',
+        value: data.source_type === 'external' && data.href ? data.href : 'https://',
         onchange: urlChange,
         onkeyup: updateText
       };

--- a/src/plugins/link/src/main/js/ui/Dialog.js
+++ b/src/plugins/link/src/main/js/ui/Dialog.js
@@ -222,7 +222,7 @@ define(
       }
 
       // Determine the source type based on the link's href value, or default to internal if empty.
-      data.source_type = Utils.isInternalUrl(data.href) || data.href === '' ? 'internal' : 'external';
+      data.source_type = (Utils.isInternalUrl(data.href) || data.href === '') && !Settings.isExternalOnly(editor) ? 'internal' : 'external';
 
       if (anchorElm) {
         data.target = dom.getAttrib(anchorElm, 'target');
@@ -253,73 +253,76 @@ define(
         onkeyup: updateText
       };
 
+      //Don't show source type options when the use external only option is specified
+      if (!Settings.isExternalOnly(editor)) {
       // If the type-ahead HTML generation didn't fail, create the internal/external toggler and separate URL controls.
-      if (typeAheadFieldHtml) {
-        sourceTypeCtrl = {
-          type: 'container',
-          label: 'Link Type',
-          layout: 'flex',
-          direction: 'row',
-          align: 'center',
-          spacing: 5,
-          items: [
-            {
-              name: 'source_type_internal',
-              type: 'checkbox',
-              checked: data.source_type === 'internal',
-              onclick: toggleLinkFields, text: 'Internal'
-            },
-            {
-              name: 'source_type_external',
-              type: 'checkbox',
-              checked: data.source_type === 'external',
-              onclick: toggleLinkFields,
-              text: 'External'
-            }
-          ]
-        };
-
-        // Set the default visibility of the external URL control.
-        hrefCtrl.hidden = data.source_type !== 'external';
-
-        // Turn the control into a container, with the original added as one of the items.
-        hrefCtrl = {
-          type: 'container',
-          name: 'linkContainer',
-          label: 'Link Source',
-          minHeight: 60,
-          items: [
-            hrefCtrl,
-            {
-              name: 'internalLink',
-              type: 'container',
-              hidden: data.source_type !== 'internal',
-              html: typeAheadFieldHtml
-            }
-          ]
-        };
-
-        var damIntegrationBrowseLabel = Utils.generateEnabledDAMIntegrationsLabelFromEditorSettings(editor);
-        if (damIntegrationBrowseLabel.length) {
-          hrefCtrl.items.push({
+        if (typeAheadFieldHtml) {
+          sourceTypeCtrl = {
             type: 'container',
-            name: 'damassetChooserLink',
-            label: '',
+            label: 'Link Type',
             layout: 'flex',
-            direction: 'column',
+            direction: 'row',
             align: 'center',
             spacing: 5,
-            hidden: true,
             items: [
               {
-                name: 'damassetChooserLinkHtml',
-                type: 'container',
-                html: '<a href="javascript:void(0);" class="damasset-chooser">Browse ' + damIntegrationBrowseLabel + ' for external files</a>'
+                name: 'source_type_internal',
+                type: 'checkbox',
+                checked: data.source_type === 'internal',
+                onclick: toggleLinkFields, text: 'Internal'
+              },
+              {
+                name: 'source_type_external',
+                type: 'checkbox',
+                checked: data.source_type === 'external',
+                onclick: toggleLinkFields,
+                text: 'External'
               }
             ]
-          });
+          };
+
+          // Set the default visibility of the external URL control.
+          hrefCtrl.hidden = data.source_type !== 'external';
+
+          // Turn the control into a container, with the original added as one of the items.
+          hrefCtrl = {
+            type: 'container',
+            name: 'linkContainer',
+            label: 'Link Source',
+            minHeight: 60,
+            items: [
+              hrefCtrl,
+              {
+                name: 'internalLink',
+                type: 'container',
+                hidden: data.source_type !== 'internal',
+                html: typeAheadFieldHtml
+              }
+            ]
+          };
+
+          var damIntegrationBrowseLabel = Utils.generateEnabledDAMIntegrationsLabelFromEditorSettings(editor);
+          if (damIntegrationBrowseLabel.length) {
+            hrefCtrl.items.push({
+              type: 'container',
+              name: 'damassetChooserLink',
+              label: '',
+              layout: 'flex',
+              direction: 'column',
+              align: 'center',
+              spacing: 5,
+              hidden: true,
+              items: [
+                {
+                  name: 'damassetChooserLinkHtml',
+                  type: 'container',
+                  html: '<a href="javascript:void(0);" class="damasset-chooser">Browse ' + damIntegrationBrowseLabel + ' for external files</a>'
+                }
+              ]
+            });
+          }
         }
-      }
+    }
 
       if (Settings.shouldShowLinkAnchor(editor.settings)) {
         anchorCtrl = {


### PR DESCRIPTION
## Scope

If the `external_only` option is specified, don't show the source type or link type in the image & link plugins

## Related issue:
- hannonhill/Cascade#3497

