### PR TITLE
fix: Remove previous class/style when there are no merged values on submit

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,21 +18,21 @@
     "test": "grunt bedrock-manual"
   },
   "dependencies": {
-    "@ephox/katamari": "^1.1.0",
+    "@ephox/katamari": "^1.1.7",
     "@ephox/sand": "^1.1.1",
-    "@ephox/sugar": "^3.1.0"
+    "@ephox/sugar": "^3.3.0"
   },
   "devDependencies": {
-    "@ephox/bedrock": "^1.5.0",
-    "@ephox/bolt": "^1.6.0",
+    "@ephox/bedrock": "^1.8.0",
+    "@ephox/bolt": "^1.9.0",
     "@ephox/imagetools": "2.0.0",
-    "@ephox/mcagar": "^1.1.1",
-    "grunt": "~1.0.1",
+    "@ephox/mcagar": "^1.2.2",
+    "grunt": "^1.0.4",
     "grunt-contrib-clean": "~1.0.0",
     "grunt-contrib-copy": "~1.0.0",
     "grunt-contrib-less": "~1.4.0",
     "grunt-contrib-uglify": "~2.0.0",
-    "grunt-contrib-watch": "~1.0.0",
+    "grunt-contrib-watch": "^1.0.1",
     "grunt-eslint": "~19.0.0",
     "grunt-nuget-pack": "^0.0.6",
     "jquery": "~1.11.3",

--- a/src/plugins/image/src/main/js/ui/Dialog.js
+++ b/src/plugins/image/src/main/js/ui/Dialog.js
@@ -353,14 +353,10 @@ define(
 
             var selectedFormatOptions = CustomStyleFormatsUtils.getSelectedFormatOptions(selectEl.options);
             var mergedClasses = CustomStyleFormatsUtils.generateClassNamesFromSelectedFormatOptions(selectedFormatOptions);
-            if (mergedClasses && mergedClasses.length) {
-              data['class'] = mergedClasses.sort().join(' ');
-            }
+            data['class'] = mergedClasses && mergedClasses.length ? mergedClasses.sort().join(' ') : null;
 
             var mergedStyles = CustomStyleFormatsUtils.mergeSelectedFormatStylesWithExistingStyles(selectEl.options, data['style']);
-            if (mergedStyles && mergedStyles.length) {
-              data['style'] = mergedStyles;
-            }
+            data['style'] = mergedStyles && mergedStyles.length ? mergedStyles : null;
           }
 
           // Setup new data excluding style properties

--- a/src/plugins/link/src/main/js/ui/Dialog.js
+++ b/src/plugins/link/src/main/js/ui/Dialog.js
@@ -437,14 +437,10 @@ define(
 
             var selectedFormatOptions = CustomStyleFormatsUtils.getSelectedFormatOptions(selectEl.options);
             var mergedClasses = CustomStyleFormatsUtils.generateClassNamesFromSelectedFormatOptions(selectedFormatOptions);
-            if (mergedClasses && mergedClasses.length) {
-              resultData['class'] = mergedClasses.sort().join(' ');
-            }
+            resultData['class'] = mergedClasses && mergedClasses.length ? mergedClasses.sort().join(' ') : null;
 
             var mergedStyles = CustomStyleFormatsUtils.mergeSelectedFormatStylesWithExistingStyles(selectEl.options, data['style']);
-            if (mergedStyles && mergedStyles.length) {
-              resultData['style'] = mergedStyles;
-            }
+            resultData['style'] = mergedStyles && mergedStyles.length ? mergedStyles : null;
           }
 
           // Is email and not //user@domain.com


### PR DESCRIPTION
hannonhill/Cascade#4119

## What was done here

- If there are no merged class or style values on submit, remove the attribute.