### PR TITLE
fix: Image assets with a plus sign in their path can't be rendered in the CMS and break WYSIWYG image menu

### DIFF
--- a/src/plugins/image/src/main/js/core/Utils.js
+++ b/src/plugins/image/src/main/js/core/Utils.js
@@ -201,7 +201,7 @@ define(
      * @return {string}
      */
     var internalPathToRenderFileURL = function (path) {
-      return path ? 'CONTEXT_PATH/render/file.act?path=' + encodeURI(path) : '';
+      return path ? 'CONTEXT_PATH/render/file.act?path=' + encodeURIComponent(path) : '';
     };
 
     /**


### PR DESCRIPTION
Related Ticket: hannonhill/Cascade#4429

Description of Changes:
* Placeholder text

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [ ] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
