### PR TITLE
fix: reverting image with plus in path fix #4429

### DIFF
--- a/src/plugins/image/src/main/js/core/Utils.js
+++ b/src/plugins/image/src/main/js/core/Utils.js
@@ -201,7 +201,7 @@ define(
      * @return {string}
      */
     var internalPathToRenderFileURL = function (path) {
-      return path ? 'CONTEXT_PATH/render/file.act?path=' + encodeURIComponent(path) : '';
+      return path ? 'CONTEXT_PATH/render/file.act?path=' + encodeURI(path) : '';
     };
 
     /**


### PR DESCRIPTION
Related Ticket: #4429

Reverting since it encodes links in the source editor as well.

Description of Changes:
* Placeholder text

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/` for new features (if applicable)

Review:
* [ ] Milestone set
* [ ] Review comments resolved

GitHub issues (if applicable):
